### PR TITLE
YTA-819 added traits for processing placeholders in the cached partials;...

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ resolvers += Resolver.bintrayRepo("hmrc", "releases")
 libraryDependencies += "uk.gov.hmrc" %% "play-partials" % "x.x.x"
 ```
 
+## Using cached static partials
+
+If you need to use a static cached partial, use the `CachedStaticHtmlPartial` trait. It will retrieve the partial from the given URL and cache it (the cache key is the partial URL) for the defined period of time. You can also pass through a map of parameters used to replace placeholders in the retrieved partial. Placeholders have the form of {{parameteKey}}.
+
+### Using HTML Form partials
+
+A special case of the static partials are HTML forms. By using `CachedStaticFormPartial` a {{csrfToken}} placeholder will be replaced with the Play CSRF token value.
+
 ## License ##
- 
+
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").

--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -53,8 +53,10 @@ object HmrcBuild extends Build {
 private object AppDependencies {
 
   import play.core.PlayVersion
+  import play.PlayImport._
 
   val compile = Seq(
+    filters,
     "com.typesafe.play" %% "play" % PlayVersion.current,
     "com.google.guava" % "guava" % "16.0.1",
 
@@ -69,6 +71,7 @@ private object AppDependencies {
   object Test {
     def apply() = new TestDependencies {
       override lazy val test = Seq(
+        "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
         "org.scalatest" %% "scalatest" % "2.2.2" % scope,
         "org.pegdown" % "pegdown" % "1.4.2" % scope,
         "org.mockito" % "mockito-all" % "1.9.5" % scope

--- a/src/main/scala/uk/gov/hmrc/play/partials/CachedStaticFormPartial.scala
+++ b/src/main/scala/uk/gov/hmrc/play/partials/CachedStaticFormPartial.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.partials
+
+import play.api.mvc.RequestHeader
+import play.twirl.api.Html
+
+trait CachedStaticFormPartial extends CachedStaticHtmlPartial {
+
+  override def processTemplate(template: Html, parameters: Map[String, String])(implicit request: RequestHeader): Html = {
+
+    val formParameters = parameters + ("csrfToken" -> getCsrfToken)
+    super.processTemplate(template, formParameters)
+
+  }
+
+  private def getCsrfToken(implicit request: RequestHeader): String = {
+    import play.filters.csrf.CSRF
+
+    CSRF.getToken(request).map{ _.value }.getOrElse("")
+  }
+}

--- a/src/main/scala/uk/gov/hmrc/play/partials/TemplateProcessor.scala
+++ b/src/main/scala/uk/gov/hmrc/play/partials/TemplateProcessor.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.partials
+
+import play.api.mvc.RequestHeader
+import play.twirl.api.Html
+
+trait TemplateProcessor {
+
+  def processTemplate(template: Html, parameters: Map[String, String])(implicit request: RequestHeader): Html = {
+    val templateString = template.toString()
+    Html(replaceTemplates(templateString, parameters))
+  }
+
+  private def replaceTemplates(s: String, parameters: Map[String, String]): String = {
+    type DataList = List[(Int, String, Int)]
+    def matchedData(from: Int, l: DataList): DataList = {
+      val end = s.lastIndexOf("}}", from)
+      if (end == -1) l
+      else {
+        val begin = s.lastIndexOf("{{", end)
+        if (begin == -1) l
+        else {
+          val template = s.substring(begin, end + 2)
+          matchedData(begin - 1, (begin, template, end + 2) :: l)
+        }
+      }
+    }
+
+    val sb = new StringBuilder(s.length)
+    var prev = 0
+    for ((begin, template, end) <- matchedData(s.length, Nil)) {
+      sb.append(s.substring(prev, begin))
+      val ident = template.substring(2, template.length - 2)
+      sb.append(parameters.getOrElse(ident, template))
+      prev = end
+    }
+    sb.append(s.substring(prev, s.length))
+    sb.toString
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/play/partials/CachedStaticFormPartialSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/partials/CachedStaticFormPartialSpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.partials
+
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpecLike}
+import play.api.test.{FakeApplication, FakeHeaders, FakeRequest, WithApplication}
+import play.filters.csrf.CSRF.Token
+import play.twirl.api.Html
+import uk.gov.hmrc.play.http.HttpGet
+
+class CachedStaticFormPartialSpec extends WordSpecLike with Matchers with MockitoSugar with BeforeAndAfterEach {
+
+  val fakeApplication = FakeApplication(additionalConfiguration = Map("csrf.sign.tokens" -> false))
+
+  val partialProvider = new CachedStaticFormPartial {
+    override def httpGet: HttpGet = ???
+  }
+
+  "processTemplate" should {
+
+    "return the original template if there is no csrf token in it" in new WithApplication(fakeApplication) {
+
+      implicit val request = FakeRequest("GET", "/getform", FakeHeaders(), "", tags = Map(Token.RequestTag -> "token"))
+
+      val template =
+        """
+          |<div>hello {{param}}</div>
+        """.stripMargin
+
+      val expectedTemplate =
+        """
+          |<div>hello world</div>
+        """.stripMargin
+
+      partialProvider.processTemplate(Html(template), Map("param" -> "world")).body shouldBe expectedTemplate
+    }
+
+    "use empty string for csrf token if there is no csrf token in the request" in new WithApplication(fakeApplication) {
+      implicit val request = FakeRequest()
+
+      val template =
+        """
+          |<div>hello {{param}} {{csrfToken}}</div>
+        """.stripMargin
+
+      val expectedTemplate =
+        """
+          |<div>hello world </div>
+        """.stripMargin
+
+
+      partialProvider.processTemplate(Html(template), Map("param" -> "world")).body shouldBe expectedTemplate
+    }
+
+    "return the template with the CSRF token placeholder replaced with the actual value" in new WithApplication(fakeApplication) {
+      implicit val request = FakeRequest("GET", "/getform", FakeHeaders(), "", tags = Map(Token.RequestTag -> "token"))
+
+      val template =
+        """
+          |<div>hello {{param}} {{csrfToken}}</div>
+        """.stripMargin
+
+      val expectedTemplate =
+        """
+          |<div>hello world token</div>
+        """.stripMargin
+
+
+      partialProvider.processTemplate(Html(template), Map("param" -> "world")).body shouldBe expectedTemplate
+    }
+
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/play/partials/CachedStaticHtmlPartialSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/partials/CachedStaticHtmlPartialSpec.scala
@@ -22,6 +22,7 @@ import org.mockito.Mockito._
 import org.mockito.{Matchers => MockitoMatchers}
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpecLike}
+import play.api.test.FakeRequest
 import play.twirl.api.Html
 import uk.gov.hmrc.play.audit.http.HeaderCarrier
 import uk.gov.hmrc.play.http.{HttpException, HttpGet, HttpReads}
@@ -67,6 +68,7 @@ class CachedStaticHtmlPartialSpec extends WordSpecLike with Matchers with Mockit
     override def expireAfter: Duration = cacheExpiryIntervalInHours.hours
   }
 
+  implicit val request = FakeRequest()
 
   override protected def beforeEach() = {
     super.beforeEach()
@@ -114,7 +116,7 @@ class CachedStaticHtmlPartialSpec extends WordSpecLike with Matchers with Mockit
       when(mockHttpGet.GET[Html](MockitoMatchers.eq("foo"))(any[HttpReads[Html]], any[HeaderCarrier]))
         .thenReturn(Future.failed(new HttpException("error", 404)))
 
-      htmlPartial.get("foo", Html("something went wrong")).body should be("something went wrong")
+      htmlPartial.get(url = "foo", errorMessage = Html("something went wrong")).body should be("something went wrong")
     }
 
     "return error message when stale value has expired and there is an exception reloading the cache" in {
@@ -127,7 +129,7 @@ class CachedStaticHtmlPartialSpec extends WordSpecLike with Matchers with Mockit
 
       testTicker.shiftTimeInHours(cacheExpiryIntervalInHours + 1)
 
-      htmlPartial.get("foo", Html("something went wrong")).body should be("something went wrong")
+      htmlPartial.get(url = "foo", errorMessage = Html("something went wrong")).body should be("something went wrong")
 
     }
 

--- a/src/test/scala/uk/gov/hmrc/play/partials/TemplateProcessorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/partials/TemplateProcessorSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.partials
+
+import org.scalatest.{Matchers, WordSpecLike}
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+
+class TemplateProcessorSpec extends WordSpecLike with Matchers {
+
+  implicit val request = FakeRequest()
+
+  val processor = new TemplateProcessor {}
+
+  "processTemplate" should {
+
+    "return the original template if there is no parameter match" in {
+      val template =
+        """
+          |<div>hello {{csrfToken}}</div>
+        """.stripMargin
+
+      processor.processTemplate(Html(template), Map.empty).body shouldBe template
+    }
+
+    "return the template with the provided placeholders replaced with the actual values" in {
+      val template =
+        """
+          |<div>hello {{csrfToken}} world {{name}} {}</div>
+        """.stripMargin
+
+      val expectedResult =
+        """
+          |<div>hello token world John {}</div>
+        """.stripMargin
+
+      processor.processTemplate(Html(template), Map("csrfToken" -> "token", "name" -> "John")).body shouldBe expectedResult
+    }
+
+  }
+
+}


### PR DESCRIPTION
... also added a helper trait that replaces the CSRF token placeholder for forms
