### PR TITLE
Add HtmlPartial type

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,52 @@ resolvers += Resolver.bintrayRepo("hmrc", "releases")
 libraryDependencies += "uk.gov.hmrc" %% "play-partials" % "x.x.x"
 ```
 
+## The `HtmlPartial` type
+
+Use this type to read an HTTP response containing a partial, and safely 
+handle the possible outcomes:
+
+* For success (2xx) status codes, an `HtmlPartial.Success`
+is returned, which contains the HTML body and optionally a hint on the title that
+should be used on the page.
+* For non-success (400 -> 599) status codes, an `HtmlPartial.Failure` is returned
+* A handler is also supplied which translates connection-related exceptions into an
+`HtmlPartial.Failure`
+
+#### Examples
+
+```scala
+import HtmlPartial._
+
+object Connector {
+	def somePartial(): Future[HtmlPartial] = 
+	  http.GET[HtmlPartial](url("/some/url")) recover connectionExceptionsAsHtmlPartialFailure
+}
+
+// Elsewhere in your service:
+Connector.partial.map(p =>
+  Ok(views.html.my_view(partial = p successfulContentOrElse Html("Sorry, there's been a problem retrieving ...")))
+)
+
+// or, if you just want to blank out a missing partial:
+Connector.partial.map(p =>
+  Ok(views.html.my_view(partial = p successfulContentOrEmpty))
+)
+
+// or, if you want to have finer-grained control:
+Connector.partial.map {
+  case HtmlPartial.Success(Some(title), content) => 
+    Ok(views.html.my_view(message = content, title = title))
+  case HtmlPartial.Success(None, content)        => 
+    Ok(views.html.my_view(message = content, title = "A fallback title"))
+  case HtmlPartial.Failure                       => 
+    Ok(views.html.my_view(message = Html("Sorry, there's been a technical problem retrieving your info"), title = "A fallback title"))
+}
+```
+
 ## Using cached static partials
 
-If you need to use a static cached partial, use the `CachedStaticHtmlPartial` trait. It will retrieve the partial from the given URL and cache it (the cache key is the partial URL) for the defined period of time. You can also pass through a map of parameters used to replace placeholders in the retrieved partial. Placeholders have the form of `{{parameterKey}}`.
+If you need to use a static cached partial, use the `CachedStaticHtmlPartialRetriever` trait. It will retrieve the partial from the given URL and cache it (the cache key is the partial URL) for the defined period of time. You can also pass through a map of parameters used to replace placeholders in the retrieved partial. Placeholders have the form of `{{parameterKey}}`.
 
 You can manage the cache parameters by overriding `refreshAfter`, `expireAfter` and `maximumEntries` attributes.
 
@@ -35,7 +78,7 @@ val partial = CachedStaticHtmlPartialProvider.get("http://my.partial")
 
 ### Using HTML Form partials
 
-A special case of the static partials are HTML forms. By using `CachedStaticFormPartial` a `{{csrfToken}}` placeholder will be replaced with the Play CSRF token value.
+A special case of the static partials are HTML forms. By using `FormPartialRetriever` a `{{csrfToken}}` placeholder will be replaced with the Play CSRF token value.
 
 ## License ##
 

--- a/src/main/scala/uk/gov/hmrc/play/partials/CachedStaticHtmlPartialRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/play/partials/CachedStaticHtmlPartialRetriever.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.play.audit.http.HeaderCarrier
 import scala.concurrent._
 import scala.concurrent.duration._
 
-trait CachedStaticHtmlPartial extends PartialRetriever {
+trait CachedStaticHtmlPartialRetriever extends PartialRetriever {
 
   val cacheTicker = new Ticker {
     override def read() = System.currentTimeMillis()

--- a/src/main/scala/uk/gov/hmrc/play/partials/FormPartialRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/play/partials/FormPartialRetriever.scala
@@ -20,6 +20,7 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 
 import scala.concurrent.Await
+import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 
 trait FormPartialRetriever extends PartialRetriever with HeaderCarrierForPartialsConverter {
 
@@ -28,8 +29,8 @@ trait FormPartialRetriever extends PartialRetriever with HeaderCarrierForPartial
     super.processTemplate(template, formParameters)
   }
 
-  override protected def loadPartial(url: String)(implicit request: RequestHeader) : Html = {
-    Await.result(httpGet.GET[Html](urlWithCsrfToken(url)), partialRetrievalTimeout)
+  override protected def loadPartial(url: String)(implicit request: RequestHeader): HtmlPartial = {
+    Await.result(httpGet.GET[HtmlPartial](urlWithCsrfToken(url)).recover(HtmlPartial.connectionExceptionsAsHtmlPartialFailure), partialRetrievalTimeout)
   }
 
   protected def getCsrfToken(implicit request: RequestHeader): String = {

--- a/src/main/scala/uk/gov/hmrc/play/partials/FormPartialRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/play/partials/FormPartialRetriever.scala
@@ -21,7 +21,7 @@ import play.twirl.api.Html
 
 import scala.concurrent.Await
 
-trait FormPartial extends PartialRetriever with HeaderCarrierForPartialsConverter {
+trait FormPartialRetriever extends PartialRetriever with HeaderCarrierForPartialsConverter {
 
   override def processTemplate(template: Html, parameters: Map[String, String])(implicit request: RequestHeader): Html = {
     val formParameters = parameters + ("csrfToken" -> getCsrfToken)

--- a/src/main/scala/uk/gov/hmrc/play/partials/HtmlPartial.scala
+++ b/src/main/scala/uk/gov/hmrc/play/partials/HtmlPartial.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.partials
+
+import play.twirl.api.Html
+import play.utils.UriEncoding
+import uk.gov.hmrc.play.http.{GatewayTimeoutException, BadGatewayException, HttpReads, HttpResponse}
+
+sealed trait HtmlPartial {
+  def successfulContentOrElse(fallbackContent: Html): Html
+  def successfulContentOrEmpty: Html = successfulContentOrElse(Html(""))
+}
+object HtmlPartial {
+  case class Success(title: Option[String], content: Html) extends HtmlPartial {
+    def successfulContentOrElse(fallbackContent: Html) = content
+  }
+  case object Failure extends HtmlPartial {
+    def successfulContentOrElse(fallbackContent: Html) = fallbackContent
+  }
+
+  trait HtmlPartialHttpReads extends HttpReads[HtmlPartial] {
+    def read(method: String, url: String, response: HttpResponse) = response.status match {
+      case s if s >= 200 && s <= 299 => Success(
+        title = response.header("X-Title").map(UriEncoding.decodePathSegment(_, "UTF-8")),
+        content = Html(response.body)
+      )
+      case _ => Failure
+    }
+  }
+
+  implicit val readsPartial = new HtmlPartialHttpReads {}
+
+  val connectionExceptionsAsHtmlPartialFailure: PartialFunction[Throwable, HtmlPartial] = {
+    case _: BadGatewayException | _: GatewayTimeoutException => HtmlPartial.Failure
+  }
+}

--- a/src/main/scala/uk/gov/hmrc/play/partials/PartialRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/play/partials/PartialRetriever.scala
@@ -28,18 +28,14 @@ trait PartialRetriever extends TemplateProcessor {
 
   def partialRetrievalTimeout: Duration = 20.seconds
 
-  protected def loadPartial(url: String)(implicit request: RequestHeader) : Html
+  protected def loadPartial(url: String)(implicit request: RequestHeader): HtmlPartial
 
-  def get(url: String, templateParameters: Map[String, String] = Map.empty, errorMessage: Html = HtmlFormat.empty)(implicit request: RequestHeader): Html = {
-    try {
-      processTemplate(loadPartial(url), templateParameters)
-    } catch {
-      case e: Throwable => {
-        val exMessage = Option(e.getCause).getOrElse(e).getMessage
-        Logger.warn(s"Cannot load partial from $url: $exMessage")
-        errorMessage
-      }
-    }
-  }
+  def getPartial(url: String, templateParameters: Map[String, String] = Map.empty)(implicit request: RequestHeader): HtmlPartial = loadPartial(url)
 
+  @deprecated(message = "Use getPartial or getPartialContent instead", since = "16/10/15")
+  def get(url: String, templateParameters: Map[String, String] = Map.empty, errorMessage: Html = HtmlFormat.empty)(implicit request: RequestHeader): Html =
+    getPartialContent(url, templateParameters, errorMessage)
+
+  def getPartialContent(url: String, templateParameters: Map[String, String] = Map.empty, errorMessage: Html = HtmlFormat.empty)(implicit request: RequestHeader): Html =
+    getPartial(url, templateParameters).successfulContentOrElse(errorMessage)
 }

--- a/src/main/scala/uk/gov/hmrc/play/partials/package.scala
+++ b/src/main/scala/uk/gov/hmrc/play/partials/package.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play
+
+package object partials {
+  @deprecated(message = "Replaced with CachedStaticHtmlPartialRetriever", since = "15/10/15")
+  type CachedStaticHtmlPartial = CachedStaticHtmlPartialRetriever
+  @deprecated(message = "Replaced with FormPartialRetriever", since = "15/10/15")
+  type FormPartial = FormPartialRetriever
+}

--- a/src/test/scala/uk/gov/hmrc/play/partials/CachedStaticHtmlPartialSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/partials/CachedStaticHtmlPartialSpec.scala
@@ -55,7 +55,7 @@ class CachedStaticHtmlPartialSpec extends WordSpecLike with Matchers with Mockit
     }
   }
 
-  val htmlPartial = new CachedStaticHtmlPartial {
+  val htmlPartial = new CachedStaticHtmlPartialRetriever {
 
     import scala.concurrent.duration._
 

--- a/src/test/scala/uk/gov/hmrc/play/partials/FormPartialSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/partials/FormPartialSpec.scala
@@ -54,42 +54,49 @@ class FormPartialSpec extends WordSpecLike with Matchers with MockitoSugar with 
 
       implicit val request = FakeRequest("GET", "/getform", FakeHeaders(), "", tags = Map(Token.RequestTag -> "token"))
 
-      when(mockHttpGet.GET[Html](MockitoMatchers.eq("foo?csrfToken=token"))(any[HttpReads[Html]], any[HeaderCarrier]))
-        .thenReturn(Future.successful(Html("some content A")))
-        .thenReturn(Future.successful(Html("some content B")))
+      when(mockHttpGet.GET[HtmlPartial](MockitoMatchers.eq("foo?csrfToken=token"))(any[HttpReads[HtmlPartial]], any[HeaderCarrier]))
+        .thenReturn(Future.successful(HtmlPartial.Success(title = None, content = Html("some content A"))))
+        .thenReturn(Future.successful(HtmlPartial.Success(title = None, content = Html("some content B"))))
 
-      partialProvider.get("foo").body should be("some content A")
-      partialProvider.get("foo").body should be("some content B")
+      val p1 = partialProvider.getPartial("foo").asInstanceOf[HtmlPartial.Success]
+      p1.title should be (None)
+      p1.content.body should be ("some content A")
+
+      val p2 = partialProvider.getPartial("foo").asInstanceOf[HtmlPartial.Success]
+      p2.title should be (None)
+      p2.content.body should be ("some content B")
     }
 
     "retrieve HTML from the given URL, which includes query string" in new WithApplication(fakeApplication) {
 
       implicit val request = FakeRequest("GET", "/getform", FakeHeaders(), "", tags = Map(Token.RequestTag -> "token"))
 
-      when(mockHttpGet.GET[Html](MockitoMatchers.eq("foo?attrA=valA&attrB=valB&csrfToken=token"))(any[HttpReads[Html]], any[HeaderCarrier]))
-        .thenReturn(Future.successful(Html("some content C")))
+      when(mockHttpGet.GET[HtmlPartial](MockitoMatchers.eq("foo?attrA=valA&attrB=valB&csrfToken=token"))(any[HttpReads[HtmlPartial]], any[HeaderCarrier]))
+        .thenReturn(Future.successful(HtmlPartial.Success(title = None, content = Html("some content C"))))
 
-      partialProvider.get("foo?attrA=valA&attrB=valB").body should be("some content C")
+      val p = partialProvider.getPartial("foo?attrA=valA&attrB=valB").asInstanceOf[HtmlPartial.Success]
+      p.title should be (None)
+      p.content.body should be ("some content C")
     }
 
-    "return HtmlFormat.empty when there is an exception retrieving the partial from the URL" in new WithApplication(fakeApplication) {
+    "return HtmlPartial.Failure when there is an exception retrieving the partial from the URL" in new WithApplication(fakeApplication) {
 
       implicit val request = FakeRequest("GET", "/getform", FakeHeaders(), "", tags = Map(Token.RequestTag -> "token"))
 
-      when(mockHttpGet.GET[Html](MockitoMatchers.eq("foo?csrfToken=token"))(any[HttpReads[Html]], any[HeaderCarrier]))
-        .thenReturn(Future.failed(new HttpException("error", 404)))
+      when(mockHttpGet.GET[HtmlPartial](MockitoMatchers.eq("foo?csrfToken=token"))(any[HttpReads[HtmlPartial]], any[HeaderCarrier]))
+        .thenReturn(Future.successful(HtmlPartial.Failure))
 
-      partialProvider.get("foo").body should be("")
+      partialProvider.getPartial("foo") should be (HtmlPartial.Failure)
     }
 
     "return provided Html when there is an exception retrieving the partial from the URL" in new WithApplication(fakeApplication) {
 
       implicit val request = FakeRequest("GET", "/getform", FakeHeaders(), "", tags = Map(Token.RequestTag -> "token"))
 
-      when(mockHttpGet.GET[Html](MockitoMatchers.eq("foo?csrfToken=token"))(any[HttpReads[Html]], any[HeaderCarrier]))
-        .thenReturn(Future.failed(new HttpException("error", 404)))
+      when(mockHttpGet.GET[HtmlPartial](MockitoMatchers.eq("foo?csrfToken=token"))(any[HttpReads[HtmlPartial]], any[HeaderCarrier]))
+        .thenReturn(Future.successful(HtmlPartial.Failure))
 
-      partialProvider.get(url = "foo", errorMessage = Html("something went wrong")).body should be("something went wrong")
+      partialProvider.getPartialContent(url = "foo", errorMessage = Html("something went wrong")).body should be("something went wrong")
     }
 
   }

--- a/src/test/scala/uk/gov/hmrc/play/partials/FormPartialSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/partials/FormPartialSpec.scala
@@ -34,7 +34,7 @@ class FormPartialSpec extends WordSpecLike with Matchers with MockitoSugar with 
 
   val mockHttpGet = mock[HttpGet]
 
-  val partialProvider = new FormPartial {
+  val partialProvider = new FormPartialRetriever {
     override val httpGet: HttpGet = mockHttpGet
 
     override val crypto = c _

--- a/src/test/scala/uk/gov/hmrc/play/partials/HtmlPartialSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/partials/HtmlPartialSpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.partials
+
+import org.scalatest.{Matchers, WordSpecLike}
+import play.utils.UriEncoding
+import uk.gov.hmrc.play.http.{BadGatewayException, GatewayTimeoutException, HttpResponse}
+
+class HtmlPartialSpec extends WordSpecLike with Matchers {
+
+  "Reading an HtmlPartial from an HTTP Response" should {
+
+    "return Success when the response status is 200" in new TestCase {
+      val response = HttpResponse(responseStatus = 200, responseString = Some(content))
+
+      val partial = HtmlPartial.readsPartial.read("someMethod", "someUrl", response)
+      partial should be (an [HtmlPartial.Success])
+      partial.asInstanceOf[HtmlPartial.Success].title should be (None)
+      partial.asInstanceOf[HtmlPartial.Success].content.body should be (content)
+    }
+
+    "return Success with a title if present in the X-title header" in new TestCase {
+      val response = HttpResponse(responseStatus = 200, responseHeaders = Map("X-Title" -> Seq(encoded_title)), responseString = Some(content))
+
+      val partial = HtmlPartial.readsPartial.read("someMethod", "someUrl", response)
+      partial should be (an [HtmlPartial.Success])
+      partial.asInstanceOf[HtmlPartial.Success].title should be (Some(title))
+      partial.asInstanceOf[HtmlPartial.Success].content.body should be (content)
+    }
+
+    "return Success with empty content if the response body is empty" in new TestCase {
+      val response = HttpResponse(responseStatus = 200)
+
+      val partial = HtmlPartial.readsPartial.read("someMethod", "someUrl", response)
+      partial should be (an [HtmlPartial.Success])
+      partial.asInstanceOf[HtmlPartial.Success].content.body should be ("")
+    }
+
+    "return Success with no content if the response status is 204" in new TestCase {
+      val response = HttpResponse(responseStatus = 204)
+
+      val partial = HtmlPartial.readsPartial.read("someMethod", "someUrl", response)
+      partial should be (an [HtmlPartial.Success])
+      partial.asInstanceOf[HtmlPartial.Success].content.body should be ("")
+    }
+
+    "return Failure if the response status is between 400 and 599" in new TestCase {
+      for (status <- 400 to 599) {
+        val response = HttpResponse(responseStatus = status)
+
+        val partial = HtmlPartial.readsPartial.read("someMethod", "someUrl", response)
+        partial should be (HtmlPartial.Failure)
+      }
+    }
+  }
+
+  "HttpReads.connectionExceptionsAsHtmlPartialFailure" should {
+    "Turn a BadGatewayException into a Failure" in {
+      HtmlPartial.connectionExceptionsAsHtmlPartialFailure(new BadGatewayException("sdf")) should be (HtmlPartial.Failure)
+    }
+    "Turn a GatewayTimeoutException into a Failure" in {
+      HtmlPartial.connectionExceptionsAsHtmlPartialFailure(new GatewayTimeoutException("sdf")) should be (HtmlPartial.Failure)
+    }
+    "Ignore other types of exception" in {
+      a [MatchError] should be thrownBy HtmlPartial.connectionExceptionsAsHtmlPartialFailure(new RuntimeException("sdf"))
+    }
+  }
+
+  trait TestCase {
+    val title = "test title"
+    val encoded_title = UriEncoding.encodePathSegment(title, "UTF-8")
+    val content = "some content"
+  }
+}


### PR DESCRIPTION
This type can be used to read an HTTP response containing a partial, and safely
handle the possible outcomes:
- For success (2xx) status codes, an `HtmlPartial.Success`
  is returned, which contains the HTML body and optionally a hint on the title that
  should be used on the page.
- For non-success (400 -> 599) status codes, an `HtmlPartial.Failure` is returned
- A handler is also supplied which translates connection-related exceptions into an
  `HtmlPartial.Failure`

By using this type, services hosting a partial will be able to simply deal with failed
partials. Examples:

Connector:

``` scala
import HtmlPartial._

object Connector {
  def somePartial(): Future[HtmlPartial] =
  http.GET[HtmlPartial](url("/some/url")) recover connectionExceptionsAsHtmlPartialFailure
}
```

Service:

``` scala
Connector.partial.map(p =>
  Ok(views.html.my_view(partial = p successfulContentOrElse Html("Sorry, there's been a problem retrieving ...")))
)
```

or

``` scala
Connector.partial.map(p =>
  Ok(views.html.my_view(partial = p successfulContentOrEmpty))
)
```

or

``` scala
import HtmlPartial._

Connector.partial.map {
  case HtmlPartial.Success(Some(title), content) => Ok(views.html.my_view(message = content, title = title))
  case HtmlPartial.Success(None, content)        => Ok(views.html.my_view(message = content, title = "A fallback title"))
  case HtmlPartial.Failure                       => Ok(views.html.my_view(message = Html("Sorry, there's been a technical problem retrieving your info"), title = "A fallback title"))
}
```
