### PR TITLE
Fixed test failing intermittently in CI due to timing issues with the…

### DIFF
--- a/src-common/test/scala/uk/gov/hmrc/play/partials/CachedStaticHtmlPartialSpec.scala
+++ b/src-common/test/scala/uk/gov/hmrc/play/partials/CachedStaticHtmlPartialSpec.scala
@@ -80,18 +80,26 @@ class CachedStaticHtmlPartialSpec
           Future.successful(HtmlPartial.Success(title = None, content = Html("some content B")))
         )
 
-      htmlPartial.getPartial("foo").futureValue shouldBe HtmlPartial.Success(title = None, content = Html("some content A"))
+      // First call - should return cached content A
+      val firstResult = htmlPartial.getPartial("foo").futureValue
+      firstResult shouldBe HtmlPartial.Success(title = None, content = Html("some content A"))
 
-      // whilst still within the refresh time the same content should be returned from cache
-      htmlPartial.getPartial("foo").futureValue shouldBe HtmlPartial.Success(title = None, content = Html("some content A"))
+      // Second call - should return cached content A
+      val secondResult = htmlPartial.getPartial("foo").futureValue
+      secondResult shouldBe HtmlPartial.Success(title = None, content = Html("some content A"))
 
       // now move beyond the refresh time
       testTicker.shiftTime(htmlPartial.refreshAfter + 1.second)
-      // first call will trigger the refresh (and return cached value)
-      htmlPartial.getPartial("foo").futureValue shouldBe HtmlPartial.Success(title = None, content = Html("some content A"))
-      Thread.sleep(2000) // give the cache time to update
-      // after that, the cache will have been updated
-      htmlPartial.getPartial("foo").futureValue shouldBe HtmlPartial.Success(title = None, content = Html("some content B"))
+
+      // Trigger refresh (this will happen asynchronously)
+      val thirdResult = htmlPartial.getPartial("foo").futureValue
+      // The first call after refresh will still return the old value
+      thirdResult shouldBe HtmlPartial.Success(title = None, content = Html("some content A"))
+
+      eventually {
+        val refreshedResult = htmlPartial.getPartial("foo").futureValue
+        refreshedResult shouldBe HtmlPartial.Success(title = None, content = Html("some content B"))
+      }
 
       verify(mockPartialFetcher, times(2))
         .fetchPartial(eqTo("foo"))(any[ExecutionContext], any[HeaderCarrier])


### PR DESCRIPTION
Fix flaky CachedStaticHtmlPartialSpec test

- Replace Thread.sleep with proper async assertions using eventually
- Improve test reliability by properly waiting for cache updates
- Fix race condition in cache refresh test
- Add better test documentation

Replaced Thread.sleep(2000) with eventually {} from ScalaTest keeps retrying the assertion until it passes or times out